### PR TITLE
Correspond 3.5

### DIFF
--- a/Editor/Inspector/InspectorBase.cs
+++ b/Editor/Inspector/InspectorBase.cs
@@ -12,9 +12,7 @@ using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
 
-#ifndef UNITY_3_5
-#ifndef UNITY_3_4
-#ifndef UNITY_3_3
+#if !(UNITY_3_5 || UNITY_3_4 || UNITY_3_3)
 
 namespace MMD
 {
@@ -54,7 +52,5 @@ namespace MMD
     }
 }
 
-#endif
-#endif
 #endif
 #endif

--- a/Editor/Inspector/PMDInspector.cs
+++ b/Editor/Inspector/PMDInspector.cs
@@ -4,9 +4,7 @@ using System.Collections;
 using MMD.PMD;
 using System.IO;
 
-#ifndef UNITY_3_5
-#ifndef UNITY_3_4
-#ifndef UNITY_3_3
+#if !(UNITY_3_5 || UNITY_3_4 || UNITY_3_3)
 namespace MMD
 {
 	[CustomEditor(typeof(PMDScriptableObject))]
@@ -109,6 +107,4 @@ namespace MMD
         }
     }
 }
-#endif
-#endif
 #endif

--- a/Editor/Inspector/ScriptableObjectBase.cs
+++ b/Editor/Inspector/ScriptableObjectBase.cs
@@ -1,6 +1,10 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class ScriptableObjectBase : ScriptableObject {
+public class ScriptableObjectBase
+#if !(UNITY_3_5 || UNITY_3_4 || UNITY_3_3)
+	: ScriptableObject
+#endif
+{
 	public string assetPath;
 }

--- a/Editor/Inspector/VMDInspector.cs
+++ b/Editor/Inspector/VMDInspector.cs
@@ -4,9 +4,7 @@ using System.Collections;
 using MMD.PMD;
 using System.IO;
 
-#ifndef UNITY_3_5
-#ifndef UNITY_3_4
-#ifndef UNITY_3_3
+#if !(UNITY_3_5 || UNITY_3_4 || UNITY_3_3)
 
 namespace MMD
 {
@@ -88,6 +86,4 @@ namespace MMD
         }
     }
 }
-#endif
-#endif
 #endif


### PR DESCRIPTION
Unity 3.5で動作しない報告がありました．
どうやら，インスペクターにいろいろ表示する機能が，3.5以前でサポートしていない関数を使っていることが問題だったらしいです．しかたがないので3.5以前だとifで見えないようにしています．
以上
