### PR TITLE
IKに依って変形された差分量が付与親の差分量として正しく計算されない事が有る不具合の修正

### DIFF
--- a/Resources/IK/BoneController.cs
+++ b/Resources/IK/BoneController.cs
@@ -12,10 +12,19 @@ public class BoneController : MonoBehaviour
 	public bool add_local;
 	public bool add_move;
 	public bool add_rotate;
-	public Vector3 delta_move = Vector3.zero;
-	public Quaternion delta_rotate = Quaternion.identity;
-	private Vector3 prev_position;
-	private Quaternion prev_rotation;
+
+	/// <summary>
+	/// 簡略化トランスフォーム
+	/// </summary>
+	[System.Serializable]
+	public class LiteTransform {
+		public Vector3 position;	// 位置
+		public Quaternion rotation;	// 回転
+		
+		public LiteTransform(Vector3 p, Quaternion r) {position = p; rotation = r;}
+	}
+	private LiteTransform prev_global_;
+	private LiteTransform prev_local_;
 
 	/// <summary>
 	/// 初回更新前処理
@@ -40,60 +49,54 @@ public class BoneController : MonoBehaviour
 	public void Process()
 	{
 		if (null != additive_parent) {
+			//付与親有りなら
+			LiteTransform additive_parent_transform = additive_parent.GetDeltaTransform(add_local);
 			if (add_move) {
-				transform.localPosition += additive_parent.delta_move * additive_rate;
+				//付与移動有りなら
+				transform.localPosition += additive_parent_transform.position * additive_rate;
 			}
 			if (add_rotate) {
+				//付与回転有りなら
 				Quaternion delta_rotate_rate;
-				if (0.0f < additive_rate) {
-					delta_rotate_rate = Quaternion.Slerp(Quaternion.identity, additive_parent.delta_rotate, additive_rate);
+				if (0.0f <= additive_rate) {
+					//正回転
+					delta_rotate_rate = Quaternion.Slerp(Quaternion.identity, additive_parent_transform.rotation, additive_rate);
 				} else {
-					Quaternion additive_parent_delta_rotate_reverse = Quaternion.Inverse(additive_parent.delta_rotate);
+					//逆回転
+					Quaternion additive_parent_delta_rotate_reverse = Quaternion.Inverse(additive_parent_transform.rotation);
 					delta_rotate_rate = Quaternion.Slerp(Quaternion.identity, additive_parent_delta_rotate_reverse, -additive_rate);
 				}
 				transform.localRotation *= delta_rotate_rate;
 			}
 		}
-
-		// IK計算
-		if (null != ik_solver) {
-			ik_solver.Solve();
-			//IK制御下の差分座標更新
-			foreach (var ik_solver_target in ik_solver_targets) {
-				ik_solver_target.UpdateDeltaTransform();
-			}
-		}
-		
-		UpdateDeltaTransform();
 	}
-	
+
 	/// <summary>
-	/// 差分量更新
+	/// 差分トランスフォーム取得
 	/// </summary>
-	public void UpdateDeltaTransform() {
-		if (add_local) {
+	/// <returns>差分トランスフォーム</returns>
+	/// <param name='is_add_local'>ローカル付与か(true:ローカル付与, false:通常付与)</param>
+	public LiteTransform GetDeltaTransform(bool is_add_local) {
+		LiteTransform result;
+		if (is_add_local) {
 			//ローカル付与(親も含めた変形量算出)
-			delta_move = transform.position - prev_position;
-			delta_rotate = Quaternion.Inverse(prev_rotation) * transform.rotation;
+			result = new LiteTransform(transform.position - prev_global_.position
+									, Quaternion.Inverse(prev_global_.rotation) * transform.rotation
+									);
 		} else {
 			//通常付与(このボーン単体での変形量算出)
-			delta_move = transform.localPosition - prev_position;
-			delta_rotate = Quaternion.Inverse(prev_rotation) * transform.localRotation;
+			result = new LiteTransform(transform.localPosition - prev_local_.position
+									, Quaternion.Inverse(prev_local_.rotation) * transform.localRotation
+									);
 		}
+		return result;
 	}
 	
 	/// <summary>
-	/// 差分基点座標更新
+	/// 差分基点トランスフォーム更新
 	/// </summary>
 	public void UpdatePrevTransform() {
-		if (add_local) {
-			//ローカル付与(親も含めた変形量算出)
-			prev_position = new Vector3(transform.position.x, transform.position.y, transform.position.z);
-			prev_rotation = new Quaternion(transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w);
-		} else {
-			//通常付与(このボーン単体での変形量算出)
-			prev_position = transform.localPosition;
-			prev_rotation = transform.localRotation;
-		}
+		prev_global_ = new LiteTransform(transform.position, transform.rotation);
+		prev_local_ = new LiteTransform(transform.localPosition, transform.localRotation);
 	}
 }

--- a/Resources/MMDEngine.cs
+++ b/Resources/MMDEngine.cs
@@ -86,19 +86,20 @@ public class MMDEngine : MonoBehaviour {
 
 	void LateUpdate() 
 	{
+		//IK反映
+		foreach (CCDIKSolver ik_script in this.ik_list) {
+			ik_script.Solve();
+		}
+
 		if (0 < bone_controllers.Length) {
 			//ボーンコントローラーが有れば(PMXなら)
+			//ボーン計算
 			foreach (BoneController bone_controller in bone_controllers) {
 				bone_controller.Process();
 			}
 			//差分基点座標更新
 			foreach (BoneController bone_controller in bone_controllers) {
 				bone_controller.UpdatePrevTransform();
-			}
-		} else {
-			//ボーンコントローラーが無ければ(PMDなら)
-			foreach (CCDIKSolver ik_script in this.ik_list) {
-				ik_script.Solve();
 			}
 		}
 	}


### PR DESCRIPTION
# 概要

頂点変形順に依って、IKに依って変形された差分量が
付与親の差分量として正しく計算されない事が有る不具合を修正しました。
# 詳細
## 修正内容

腰キャンセルボーンを持つモデルに於ける足周りの頂点スキニングは下記3つのボーンが連携する事で行われます。

&nbsp;&nbsp;A. IKボーン
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ユーザーが足を操作する為に移動させるボーン
&nbsp;&nbsp;B. IK変形対象ボーン
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;IKボーンの移動に伴い、インバースキネマティクスアルゴリズムに従って移動するボーン
&nbsp;&nbsp;C. Bを付与親として持つ頂点ウェイト参照ボーン
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;このボーンが動いて初めて頂点はスキニングされます

Tda式アペンドミクさんは、これらのボーンの変形順番が B→A→C と為っています。
前回迄の差分量初期化と更新・参照タイミングではこれで正常に動作しました。
1. 全ボーンの差分量を零化(Bの差分量≒零)
2. Bボーンの更新(Bの差分量≒ΔB)
3. Aボーンの更新(Bの差分量≒ΔB + AのIK)
4. Cボーンの更新(付与親の差分量≒Bの差分量≒ΔB + AのIK)

しかしula式巡音ルカさん他のモデルに於いてボーンの変形順番が B→C→A と言う並びが有り、
この場合に、IKの変形が頂点スキニングの変形に伝わっていませんでした。
1. 全ボーンの差分量を零化(Bの差分量≒零)
2. Bボーンの更新(Bの差分量≒ΔB)
3. Cボーンの更新(付与親の差分量≒Bの差分量≒ΔB)) ←AのIKが伝わっていない
4. Aボーンの更新(Bの差分量≒ΔB + AのIK)

これを改善する為に、IKのみ変形を先行して行う2パスにしました。
1. 全ボーンの差分量を零化(Bの差分量≒零)
2. 全ボーンのIKを更新(Bの差分量≒AのIK)
3. Bボーンの更新(Bの差分量≒AのIK + ΔB)
4. Cボーンの更新(付与親の差分量≒Bの差分量≒AのIK + ΔB)) ←AのIKが伝わる
5. Aボーンの更新(Bの差分量≒AのIK + ΔB)

この対応に依り B→A→C でも B→C→A でもIKが正常に伝達される様に為りました。
## 問題点

この対応に於ける最大の問題点はPMX仕様書に記述されている変形仕様と異なる事です。

> ●ボーン変形
> □変形順序
> ボーンの変形順序は
> (中略)
> 順に変形を行う。
> 1つのボーンにおけるローカル変形処理はIKからのリンク参照を除いて1回のみ。
> (PMX仕様 ver2.1依り)

引用の様にボーンの変形処理は各々1回で完結するので、本来ならば1パスの筈です。
ですので2パスの今方式は、PMXの変形としては明らかに間違っています。

では今回の変換方式の影響は何処かと言うと、よく分かっていません。
想像するに“IK変形の適応が1フレーム早く為る。”様な気がします。、
と言う依り正確には“PMXの仕様ではIK変形の適応が1フレーム遅れるけれど、今方式ではそれがエミュレート出来ていない。”様な気がします。、
様な気がしますと弱気なのはMMDでIK変形の適応が1フレーム遅れている様に見えないからです。

今方式でも正常に動作しないモデルの存在を確認していますのでまだ色々問題を含んだ付与親計算式だと思いますが、
改善されたモデルは居ても悪化したモデルが居ないので取り敢えずPullRequest出しておきます。
## テストモデル

| 作者名 式 モデル名 (バージョン) | 結果 | 備考 |
| --- | --- | --- |
| ula式巡音ルカ(Ver3.11) | ○ | 今回の変更に依り正常化 |
| K-Masaki.jp式銀次郎(20130612b) | △ | まだIKか付与親がおかしい |
| あにまさ式初音ミク(MMD Ver.8.03(x64)付属) | ○ | 以前から正常、変更に依る不具合は見られない |
| Lat式ミク(Ver2.3) | ○ | 以前から正常、変更に依る不具合は見られない |
| Tda式初音ミク・アペンド(Ver1.00) | ○ | 以前から正常、変更に依る不具合は見られない |
