### PR TITLE
材質・剛体にファイル名として使用出来無い文字が含まれていると変換に失敗する不具合の修正

### DIFF
--- a/Editor/MMDLoader/Private/MMDConverter.cs
+++ b/Editor/MMDLoader/Private/MMDConverter.cs
@@ -614,7 +614,7 @@ namespace MMD
 				material.staticFriction = rigid.rigidbody_friction;
 				material.dynamicFriction = rigid.rigidbody_friction;
 
-				AssetDatabase.CreateAsset(material, format_.folder + "/Physics/" + material.name + ".asset");
+				AssetDatabase.CreateAsset(material, format_.folder + "/Physics/" + GetFilePathString(material.name) + ".asset");
 				return material;
 			}
 
@@ -982,7 +982,26 @@ namespace MMD
 				}
 				return result;
 			}
-		
+			
+			/// <summary>
+			/// ファイルパス文字列の取得
+			/// </summary>
+			/// <returns>ファイルパスに使用可能な文字列</returns>
+			/// <param name='src'>ファイルパスに使用したい文字列</param>
+			private static string GetFilePathString(string src) {
+				return src.Replace('\\', '＼')
+							.Replace('/',  '／')
+							.Replace(':',  '：')
+							.Replace('*',  '＊')
+							.Replace('?',  '？')
+							.Replace('"',  '”')
+							.Replace('<',  '＜')
+							.Replace('>',  '＞')
+							.Replace('|',  '｜')
+							.Replace("\n",  string.Empty)
+							.Replace("\r",  string.Empty);
+			}
+
 			GameObject	root_game_object_;
 			PMDFormat	format_;
 			ShaderType	shader_type_;

--- a/Editor/MMDLoader/Private/PMXConverter.cs
+++ b/Editor/MMDLoader/Private/PMXConverter.cs
@@ -325,7 +325,8 @@ namespace MMD
 				AssetDatabase.CreateFolder(format_.meta_header.folder, "Meshes");
 			}
 			
-			string file_name = path + index.ToString() + "_" + format_.meta_header.name + ".asset";
+			string name = GetFilePathString(format_.meta_header.name);
+			string file_name = path + index.ToString() + "_" + name + ".asset";
 			AssetDatabase.CreateAsset(mesh, file_name);
 		}
 		
@@ -569,7 +570,7 @@ namespace MMD
 			
 			for (int i = 0, i_max = materials.Length; i < i_max; ++i) {
 				uint material_index = creation_info.value[i].material_index;
-				string name = format_.material_list.material[material_index].name;
+				string name = GetFilePathString(format_.material_list.material[material_index].name);
 				string file_name = path + material_index.ToString() + "_" + name + ".asset";
 				AssetDatabase.CreateAsset(materials[i], file_name);
 			}
@@ -1283,8 +1284,10 @@ namespace MMD
 			material.bounciness = rigidbody.recoil;
 			material.staticFriction = rigidbody.friction;
 			material.dynamicFriction = rigidbody.friction;
-
-			AssetDatabase.CreateAsset(material, format_.meta_header.folder + "/Physics/" + index.ToString() + "_" + rigidbody.name + ".asset");
+			
+			string name = GetFilePathString(rigidbody.name);
+			string file_name = format_.meta_header.folder + "/Physics/" + index.ToString() + "_" + name + ".asset";
+			AssetDatabase.CreateAsset(material, file_name);
 			return material;
 		}
 
@@ -1632,7 +1635,25 @@ namespace MMD
 		{
 			return format_.rigidbody_list.rigidbody.Select(x=>(int)x.ignore_collision_group).ToArray();
 		}
-	
+		
+		/// <summary>
+		/// ファイルパス文字列の取得
+		/// </summary>
+		/// <returns>ファイルパスに使用可能な文字列</returns>
+		/// <param name='src'>ファイルパスに使用したい文字列</param>
+		private static string GetFilePathString(string src) {
+			return src.Replace('\\', '＼')
+						.Replace('/',  '／')
+						.Replace(':',  '：')
+						.Replace('*',  '＊')
+						.Replace('?',  '？')
+						.Replace('"',  '”')
+						.Replace('<',  '＜')
+						.Replace('>',  '＞')
+						.Replace('|',  '｜')
+						.Replace("\n",  string.Empty)
+						.Replace("\r",  string.Empty);
+		}
 
 		const uint	c_max_vertex_count_in_mesh = 65535; //meshに含まれる最大頂点数(Unity3D的には65536迄入ると思われるが、ushort.MaxValueは特別な値として使うのでその分を除外)
 


### PR DESCRIPTION
# 概要

材質・剛体にファイル名として使用出来無い文字が含まれていると変換に失敗する不具合を修正しました。
# 詳細
## 修正内容

材質名・剛体名を元にファイル名が生成される箇所に於いてWindowsのファイル名として使用出来無い下記9種類が含まれる事に為ったら全角にエスケープする様にしました。
&nbsp;&nbsp;&nbsp;&nbsp;\/:*?"<>|
また、もし改行が含まれていた場合には除去する様にしています。
## 問題点

Mac側だと9種類もエスケープしなくて良いと思いますが、
UnityEditorがMac上で動いている事を入手する手段が分からなかったので、取り敢えず区別していません。
# テストモデル

| 作者名 式 モデル名 (バージョン) | 結果 | 備考 |
| --- | --- | --- |
| 化身バレッタ式セルシアナ(Ver4.8) | ○ | 今回の変更に依り正常化 |
| まれよん式初音ミク(ver1.3.9h) | ○ | 今回の変更に依り正常化 |
| あにまさ式初音ミク(MMD Ver.8.03(x64)付属) | ○ | 以前から正常、変更に依る不具合は見られない |
| Lat式ミク(Ver2.3) | ○ | 以前から正常、変更に依る不具合は見られない |
| Tda式初音ミク・アペンド(Ver1.00) | ○ | 以前から正常、変更に依る不具合は見られない |
