### PR TITLE
MorphManager:全対象材質モーフが存在しないモデルに於いて、モーフ対象材質の最後1つが機能しない不具合の修正

### DIFF
--- a/Resources/Morph/MorphManager.cs
+++ b/Resources/Morph/MorphManager.cs
@@ -297,8 +297,14 @@ public class MorphManager : MonoBehaviour
 			
 			if (is_update) {
 				//全材質計算
+				bool has_all_target = false;
 				if (-1 == material_morph.meshes[0].indices.LastOrDefault()) {
 					//最後に-1(≒uint.MaxValue)が有れば
+					//全材質モーフが有る
+					has_all_target = true;
+				}
+				if (has_all_target) {
+					//全材質モーフが有れば
 					//全材質に反映
 					MaterialMorph.MaterialMorphParameter composite_mul_all = composite_mul.Last();
 					MaterialMorph.MaterialMorphParameter composite_add_all = composite_add.Last();
@@ -310,7 +316,7 @@ public class MorphManager : MonoBehaviour
 				
 				// ここで計算結果を入れていく
 				for (int r = 0, r_max = renderers.Length; r < r_max; ++r) {
-					for (int m = 0, m_max = material_morph.source.Length - 1; m < m_max; ++m) {
+					for (int m = 0, m_max = material_morph.source.Length - ((has_all_target)? 1: 0); m < m_max; ++m) {
 						int index = material_morph.meshes[r].indices[m];
 						if (index < renderer_shared_materials_[r].Length) {
 							ApplyMaterialMorph(renderer_shared_materials_[r][index]


### PR DESCRIPTION
# 概要

全対象材質モーフが存在しないモデルに於いて、モーフ対象材質の最後1つが機能しない不具合を修正しました。
# 詳細
## 修正内容

材質モーフの中でも全マテリアルに影響を与える種類のモーフ(全対象モーフ)は、最後に配置して特別扱いしていました。
材質モーフの中に全対象モーフが1つも無い場合最後を特別扱いする必要は無いのですが、マテリアルの値を変更する箇所で常に特別扱いしていました。
その結果、全対象モーフを持たないモデルにて最後のマテリアル値が書き換わらなく為っていました。
そちらを修正しました。
## 問題点

特に有りません。
# テストモデル

Tda式初音ミク・アペンド(Ver1.00)
“AL未使用”モーフにて“wing(腰付近にぶら下がっている半透明緑色の装飾)”の色が変化する様に為ります
