### PR TITLE
MMDConverter:QualitySettingsのBlendWeightsを4bonesにするとモデルが巨大化する不具合の修正

### DIFF
--- a/Editor/MMDLoader/Private/MMDConverter.cs
+++ b/Editor/MMDLoader/Private/MMDConverter.cs
@@ -132,8 +132,8 @@ namespace MMD
 				{
 					weights[i].boneIndex0 = (int)format_.vertex_list.vertex[i].bone_num[0];
 					weights[i].boneIndex1 = (int)format_.vertex_list.vertex[i].bone_num[1];
-					weights[i].weight0 = format_.vertex_list.vertex[i].bone_weight;
-					weights[i].weight1 = 100 - format_.vertex_list.vertex[i].bone_weight;
+					weights[i].weight0 = (float)format_.vertex_list.vertex[i].bone_weight / 100.0f;
+					weights[i].weight1 = 1.0f - weights[i].weight0;
 				}
 				return weights;
 			}


### PR DESCRIPTION
# 概要

Unity3DのQualitySettings(メニュー/Edit/Project Settings/Quality)にてBlend Weightsを4Bonesに設定すると、
PMDConverterにてインポートしたモデルが巨大化する不具合を修正しました。
# 詳細
## 修正内容

頂点のボーンウェイトにPMDフォーマット譲りで0～100が設定されていましたが、
100で割って0.0f～1.0fを設定する様にしました。
## 問題点

SkinnedMeshRentererのQualityを2Bonesに設定する事でも巨大化は防げます。
しかしそれを設定してしまうと、多分QualitySettingsのBlend Weights設定が
効かなくなると思うので宜しく無いだろうと思います(未検証)。
# テストモデル

| 作者名 式 モデル名 (バージョン) | 備考 |
| --- | --- |
| あにまさ式初音ミク(MMD Ver.8.03(x64)付属) |  |
| Lat式ミク(Ver2.3) |  |
| mqdl式初音ミクXS(rev.c) |  |
| Tda式初音ミク・アペンド(Ver1.00) | Use PMX Base Importオフ |
