### PR TITLE
リスケール対応

### DIFF
--- a/Editor/Config/Config.cs
+++ b/Editor/Config/Config.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor;
 using System;
 using System.Collections.Generic;
@@ -116,6 +116,7 @@ namespace MMD
         public bool use_mecanim = false;
         public bool rigidFlag = true;
         public bool use_ik = true;
+        public float scale = 0.085f;
         public bool is_pmx_base_import = false;
 
         public DefaultPMDImportConfig()

--- a/Editor/Inspector/PMDInspector.cs
+++ b/Editor/Inspector/PMDInspector.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor;
 using System.Collections;
 using MMD.PMD;
@@ -15,6 +15,7 @@ namespace MMD
         public bool rigidFlag;
         public bool use_mecanim;
         public bool use_ik;
+        public float scale;
         public bool is_pmx_base_import;
 
         // last selected item
@@ -32,6 +33,7 @@ namespace MMD
             rigidFlag = config.pmd_config.rigidFlag;
             use_mecanim = config.pmd_config.use_mecanim;
             use_ik = config.pmd_config.use_ik;
+            scale = config.pmd_config.scale;
             is_pmx_base_import = config.pmd_config.is_pmx_base_import;
 			
             // モデル情報
@@ -63,13 +65,29 @@ namespace MMD
             rigidFlag = EditorGUILayout.Toggle("Rigidbody", rigidFlag);
 
             // Mecanimを使うかどうか
-            use_mecanim = EditorGUILayout.Toggle("Use Mecanim (not work)", use_mecanim);
+            GUI.enabled = false;
+            use_mecanim = EditorGUILayout.Toggle("Use Mecanim", false);
+            GUI.enabled = !EditorApplication.isPlaying;
 
             // IKを使うかどうか
             use_ik = EditorGUILayout.Toggle("Use IK", use_ik);
 
+            // スケール
+            scale = EditorGUILayout.Slider("Scale", scale, 0.001f, 1.0f);
+            EditorGUILayout.BeginHorizontal();
+            {
+                EditorGUILayout.PrefixLabel(" ");
+                if (GUILayout.Button("0.085", EditorStyles.miniButtonLeft)) {
+                    scale = 0.085f;
+                }
+                if (GUILayout.Button("1.0", EditorStyles.miniButtonRight)) {
+                    scale = 1.0f;
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+
             // PMX Baseでインポートするかどうか
-            is_pmx_base_import = EditorGUILayout.Toggle("Use PMX Base Exporter", is_pmx_base_import);
+            is_pmx_base_import = EditorGUILayout.Toggle("Use PMX Base Import", is_pmx_base_import);
 
             // Convertボタン
             EditorGUILayout.Space();
@@ -85,7 +103,7 @@ namespace MMD
 						var obj = (PMDScriptableObject)target;
                         model_agent = new ModelAgent(obj.assetPath);
                     }
-                    model_agent.CreatePrefab(shader_type, rigidFlag, use_mecanim, use_ik, is_pmx_base_import);
+                    model_agent.CreatePrefab(shader_type, rigidFlag, use_mecanim, use_ik, scale, is_pmx_base_import);
                     message = "Loading done.";
                 }
             }

--- a/Editor/MMDLoader/Private/ModelAgent.cs
+++ b/Editor/MMDLoader/Private/ModelAgent.cs
@@ -35,8 +35,9 @@ namespace MMD {
 		/// <param name='use_rigidbody'>剛体を使用するか</param>
 		/// <param name='use_mecanim'>Mecanimを使用するか</param>
 		/// <param name='use_ik'>IKを使用するか</param>
+		/// <param name='scale'>スケール</param>
 		/// <param name='is_pmx_base_import'>PMX Baseでインポートするか</param>
-		public void CreatePrefab(PMD.PMDConverter.ShaderType shader_type, bool use_rigidbody, bool use_mecanim, bool use_ik, bool is_pmx_base_import) {
+		public void CreatePrefab(PMD.PMDConverter.ShaderType shader_type, bool use_rigidbody, bool use_mecanim, bool use_ik, float scale, bool is_pmx_base_import) {
 			GameObject game_object;
 			Object prefab;
 			if (is_pmx_base_import) {
@@ -44,7 +45,7 @@ namespace MMD {
 				//PMXファイルのインポート
 				PMX.PMXFormat format = PMXLoaderScript.Import(file_path_);
 				//ゲームオブジェクトの作成
-				game_object = PMXConverter.CreateGameObject(format, use_rigidbody, use_mecanim, use_ik);
+				game_object = PMXConverter.CreateGameObject(format, use_rigidbody, use_mecanim, use_ik, scale);
 	
 				// プレファブに登録
 				prefab = PrefabUtility.CreateEmptyPrefab(format.meta_header.folder + "/" + format.meta_header.name + ".prefab");
@@ -65,7 +66,7 @@ namespace MMD {
 				}
 	
 				//ゲームオブジェクトの作成
-				game_object = PMDConverter.CreateGameObject(format_, shader_type, use_rigidbody, use_mecanim, use_ik);
+				game_object = PMDConverter.CreateGameObject(format_, shader_type, use_rigidbody, use_mecanim, use_ik, scale);
 	
 				// プレファブに登録
 				prefab = PrefabUtility.CreateEmptyPrefab(format_.folder + "/" + format_.name + ".prefab");

--- a/Resources/MMDEngine.cs
+++ b/Resources/MMDEngine.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 public class MMDEngine : MonoBehaviour {
 
+	public float scale = 1.0f;		//読み込みスケール
 	public float outline_width = 0.1f;
 	public bool useRigidbody = false;
 	public int[] groupTarget;		// 非衝突剛体リスト
@@ -104,10 +105,11 @@ public class MMDEngine : MonoBehaviour {
 		}
 	}
 
-	public static void Initialize(MMDEngine engine, int[] groupTarget, List<int>[] ignoreGroups, GameObject[] rigidArray)
+	public static void Initialize(MMDEngine engine, float scale, int[] groupTarget, List<int>[] ignoreGroups, GameObject[] rigidArray)
 	{
 		if (!engine.useRigidbody)
 		{
+			engine.scale = scale;
 			engine.groupTarget = groupTarget;
 			engine.rigids = rigidArray;
 			engine.useRigidbody = true;


### PR DESCRIPTION
# 概要

Unity3Dは内部座標の1.0を1mとして扱うのを推奨しています。
MMD付属のあにまさ式初音ミクはMMD座標で20.0ぐらいの高さが有る為、
PMD・PMXの頂点データをそのままUnity3D座標にマッピングすると約20mの巨人と扱われてしまいます。
これを解消する為に頂点データや物理データをスケール変換しつつインポート出来る様に拡張します。
# 詳細
## 修正内容

下記データにスケール値を乗算しつつインポートします。

| PMD | PMX | VMD |
| :-: | :-: | :-: |
| 頂点/座標 | 頂点/位置 |  |
| ボーン/ボーン座標 | ボーン位置 | ボーン座標 |
| 表情/頂点オフセット | モーフ/頂点モーフ/オフセット量/頂点 |  |
|  | モーフ/ボーンモーフ/オフセット量/ボーン移動 |  |
| 剛体/位置 | 剛体/位置 |  |
| 剛体/サイズ | 剛体/サイズ |  |
| Joint/ばね/移動 | Joint/ばね/移動 |  |
## 問題点
### MMDデータをインポートする時の正しいスケール値が不明

一応、インターフェース上では0.001f～1.0fの間で任意に設定出来る様にしていますが、
ユーザー側に推奨値を調査させるのはおかしい話です。
依って、後述する調査結果を元に独断と偏見で推奨値兼初期値を設定しています。
設定した推奨値兼初期値は0.085fです。

MMDモデルに於いて身長を求める為に参照出来る値は2つ考えられました。
1つは初音ミクさんの公式身長です。
公式身長は158cmですのでモデラーさんがそれを元に各種調整を行っていると過程すると、
Unity3D上では1.58程度の身長に成れば良い事に為ります
MMD Ver.8.03(x64)付属のあにまさ式初音ミクさんが大体20.12程度ですので、
この場合は0.0785倍程度が推奨されます。

もう1つがMMDにて使用されている物理演算です。
MMD Ver.8.03(x64)付属のあにまさ式初音ミクさんの頭から盥を落とした場合、
地面に着く迄に37フレーム(60fps時)掛かりました。
重力加速度が地球と同等と仮定すると身長は1.86m程度と為り、
この場合は0.0926倍程度が推奨されます。

2つの値には結構差が有りますが、特に何も考えず間を取って0.085fを推奨値としました。
より最適な値が有ればそちらに変更可能です。
### VMDインポート時にPMD・PMXインポート時のスケール情報が必要

身体にスケールが掛かると移動量にもスケールが掛かりますのでVMDの移動オフセットもスケールを掛けないといけません。
既存のままではPMD・PMXインポート時のスケール情報を算出する事が出来ませんでしたので、
MMDEngineにインポート時のスケール情報を格納する変数を追加しています。

追加した変数はpublic扱いにしていますので変更可能です。
変更されるとその後のVMDインポートに支障が出ますが、特に改変防止対策は仕組んでいません。
### 同じモデルのAnimationClipでもスケールが違うと使いまわせない

割り切りましょう。
最初はスケール情報をファイル名に仕組んでいたのですが、
1つのプロジェクトにスケール変えて同じモデルをインポートする事はまず無い気がしたので外しました。

(某巨人アニメを再現するなら巨大な人物が必要に為るのですが、
その場合TransformのScaleを大きくして使用しそうな気がします。)
### スケールスライダーで拡大出来無い

スライダーだと最大値・最小値を設定しないといけなかったので、取り敢えず0.001f～1.0fを設定しました。
この設定だと拡大は出来ません。

個人的には今後は推奨値の1択で良いと思っていて、
後方互換を考えても推奨値と等倍の2択で良いのじゃないかなと思っています。
Unity3DはMMDと違ってTransformにScaleが有るので基本はそちらを使うべきだと考えています。
では何故本機能が必要かというと、等倍インポートだとMMDと重力加速度が違い過ぎる(≒スケールが有ってない)からです。
「インポート後にTransformのScaleを0.085にすれば大体物理が合うよ。」と書かれていれば
ユーザーはその様に対応してくれると思いますが、私は
「分かってるのなら、それも含めてインポートしてよ。」と思います。
「初期設定で物理含めてUnity3Dで大体それっぽく動く。」が重要で、
それは多分推奨値の1択を提供していれば十分な気がします。

と、まぁ色々書きましたが、
スケールスライダーの最大値・最小値は取り敢えず設定しただけなので変更可能です。
# テストモデル
- あにまさ式初音ミク(MMD Ver.8.03(x64)付属)
- Lat式ミク(Ver2.3)
- mqdl式初音ミクXS(rev.c)
- Tda式初音ミク・アペンド(Ver1.00)
- まれよん式初音ミク(ver1.3.9h)
- おんだ式初音ミク(Ver.1.21)
- ぴくちぃ式ミク(v1.3)
