### PR TITLE
PMD・PMXインポート時にRigidbodyを有効にしておかないとVMDインポート時にスケールが反映されない不具合の修正

### DIFF
--- a/Editor/MMDLoader/Private/MMDConverter.cs
+++ b/Editor/MMDLoader/Private/MMDConverter.cs
@@ -63,6 +63,7 @@ namespace MMD
 				root_game_object_.AddComponent<Animation>();	// アニメーションを追加
 		
 				MMDEngine engine = root_game_object_.AddComponent<MMDEngine>();
+				engine.scale = scale_;
 		
 				// IKの登録
 				if (use_ik_)
@@ -83,7 +84,7 @@ namespace MMD
 						List<int>[] ignoreGroups = SettingIgnoreRigidGroups(rigids);
 						int[] groupTarget = GetRigidbodyGroupTargets(rigids);
 		
-						MMDEngine.Initialize(engine, scale_, groupTarget, ignoreGroups, rigids);
+						MMDEngine.Initialize(engine, groupTarget, ignoreGroups, rigids);
 					}
 					catch { }
 				}

--- a/Editor/MMDLoader/Private/PMXConverter.cs
+++ b/Editor/MMDLoader/Private/PMXConverter.cs
@@ -45,6 +45,7 @@ namespace MMD
 			scale_ = scale;
 			root_game_object_ = new GameObject(format_.meta_header.name);
 			MMDEngine engine = root_game_object_.AddComponent<MMDEngine>(); //MMDEngine追加
+			engine.scale = scale_;
 			root_game_object_.AddComponent<Animation>();	// アニメーションを追加
 		
 			MeshCreationInfo[] creation_info = CreateMeshCreationInfo();				// メッシュを作成する為の情報を作成
@@ -75,7 +76,7 @@ namespace MMD
 				List<int>[] ignoreGroups = SettingIgnoreRigidGroups(rigids);
 				int[] groupTarget = GetRigidbodyGroupTargets(rigids);
 
-				MMDEngine.Initialize(engine, scale_, groupTarget, ignoreGroups, rigids);
+				MMDEngine.Initialize(engine, groupTarget, ignoreGroups, rigids);
 			}
 	
 			// Mecanim設定 (not work yet..)

--- a/Resources/MMDEngine.cs
+++ b/Resources/MMDEngine.cs
@@ -105,11 +105,10 @@ public class MMDEngine : MonoBehaviour {
 		}
 	}
 
-	public static void Initialize(MMDEngine engine, float scale, int[] groupTarget, List<int>[] ignoreGroups, GameObject[] rigidArray)
+	public static void Initialize(MMDEngine engine, int[] groupTarget, List<int>[] ignoreGroups, GameObject[] rigidArray)
 	{
 		if (!engine.useRigidbody)
 		{
-			engine.scale = scale;
 			engine.groupTarget = groupTarget;
 			engine.rigids = rigidArray;
 			engine.useRigidbody = true;


### PR DESCRIPTION
# 概要

PMD・PMXインポート時にRigidbodyを有効にしておかないと、
VMDインポート時にスケールが1.0として扱われてしまう不具合を修正しました。

PMD・PMXインポート時に1.0以外のスケールを選択し、かつRigidbodyを有効にしなかった場合に於いて、
VMDインポートのモーションがおかしい不具合が修正されます。
# 詳細
## 修正内容

MMDEngineのscale値を、Rigidbodyが有効な場合にしか設定していなかった不具合を修正しました。
## 問題点

特に有りません。
# テストモデル
- Tda式初音ミク・アペンド(Ver1.00)
