### PR TITLE
エッジ描画の調整

### DIFF
--- a/Editor/MMDLoader/Private/MMDConverter.cs
+++ b/Editor/MMDLoader/Private/MMDConverter.cs
@@ -62,7 +62,10 @@ namespace MMD
 				BuildingBindpose(mesh, materials, bones);
 		
 				MMDEngine engine = root_game_object_.AddComponent<MMDEngine>();
+				//スケール・エッジ幅
 				engine.scale = scale_;
+				engine.outline_width = default_outline_width;
+				engine.material_outline_widths = Enumerable.Repeat(1.0f, materials.Length).ToArray();
 		
 				// IKの登録
 				if (use_ik_)
@@ -326,10 +329,11 @@ namespace MMD
 							mats[i].SetFloat("_Opacity", pmdMat.alpha);
 							mats[i].SetColor("_SpecularColor", pmdMat.specular_color);
 							mats[i].SetFloat("_Shininess", pmdMat.specularity);
+							// エッジ
+							const float c_default_scale = 0.085f; //0.085fの時にMMDと一致する様にしているので、それ以外なら補正
+							mats[i].SetFloat("_OutlineWidth", default_outline_width * scale_ / c_default_scale);
+							mats[i].SetColor("_OutlineColor", default_outline_color);
 						
-							//　エッジ
-							mats[i].SetFloat("_OutlineWidth", 0.2f);	// これぐらいがいい気がする
-
 							// ここでスフィアマップ
 							string path = format_.folder + "/" + pmdMat.sphere_map_name;
 							Texture sphere_map;
@@ -1003,7 +1007,10 @@ namespace MMD
 							.Replace("\n",  string.Empty)
 							.Replace("\r",  string.Empty);
 			}
-
+			
+			static float default_outline_width = 0.2f;			//標準エッジ幅
+			static Color default_outline_color = Color.black;	//標準エッジ色
+			
 			GameObject	root_game_object_;
 			PMDFormat	format_;
 			ShaderType	shader_type_;

--- a/Editor/MMDLoader/Private/PMXConverter.cs
+++ b/Editor/MMDLoader/Private/PMXConverter.cs
@@ -45,8 +45,11 @@ namespace MMD
 			scale_ = scale;
 			root_game_object_ = new GameObject(format_.meta_header.name);
 			MMDEngine engine = root_game_object_.AddComponent<MMDEngine>(); //MMDEngine追加
+			//スケール・エッジ幅
 			engine.scale = scale_;
-		
+			engine.outline_width = 1.0f;
+			engine.material_outline_widths = format.material_list.material.Select(x=>x.edge_size).ToArray();
+			
 			MeshCreationInfo[] creation_info = CreateMeshCreationInfo();				// メッシュを作成する為の情報を作成
 			Mesh[] mesh = CreateMesh(creation_info);									// メッシュの生成・設定
 			Material[][] materials = CreateMaterials(creation_info);					// マテリアルの生成・設定
@@ -470,7 +473,8 @@ namespace MMD
 			result.SetColor("_SpecularColor", material.specular_color);
 			result.SetFloat("_Shininess", material.specularity);
 			// エッジ
-			result.SetFloat("_OutlineWidth", material.edge_size);
+			const float c_default_scale = 0.085f; //0.085fの時にMMDと一致する様にしているので、それ以外なら補正
+			result.SetFloat("_OutlineWidth", material.edge_size * scale_ / c_default_scale);
 			result.SetColor("_OutlineColor", material.edge_color);
 
 			// スフィアテクスチャ

--- a/Resources/MMDEngine.cs
+++ b/Resources/MMDEngine.cs
@@ -6,12 +6,15 @@ using System.Linq;
 public class MMDEngine : MonoBehaviour {
 
 	public float scale = 1.0f;		//読み込みスケール
-	public float outline_width = 0.1f;
 	public bool useRigidbody = false;
 	public int[] groupTarget;		// 非衝突剛体リスト
 	public GameObject[] rigids;		// 剛体リスト
 	public GameObject[] joints;     // ConfigurableJointの入っているボーンのリスト
-
+#if UNITY_EDITOR
+	public float outline_width;				//エッジ幅係数(エディタ用)
+	public float[] material_outline_widths; //材質のエッジ幅(エディタ用)
+#endif
+	
 	// 訳があってこうなってる
 	public int[] ignore1;
 	public int[] ignore2;
@@ -39,12 +42,6 @@ public class MMDEngine : MonoBehaviour {
 	// Use this for initialization
 	void Start () 
 	{
-		SkinnedMeshRenderer[] renderers = GetComponentsInChildren<SkinnedMeshRenderer>();
-		foreach (var m in renderers.SelectMany(x=>x.sharedMaterials))
-		{
-			m.SetFloat("_OutlineWidth", this.outline_width);
-		}
-
 		if (useRigidbody)
 		{
 			ignoreList = new List<int[]>();

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterialVertFrag.cginc
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterialVertFrag.cginc
@@ -29,14 +29,15 @@ struct v2f
 v2f vert( appdata_base v )
 {
 	v2f o;
-	float4 pos = mul( UNITY_MATRIX_MVP, v.vertex );
-	float width = 0.01 * _OutlineWidth;
-	float4 edge_pos = v.vertex + pos.w * width * float4( v.normal, 0.0 );
-	o.pos = mul( UNITY_MATRIX_MVP, edge_pos );
+	float4 pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	float4 normal = mul(UNITY_MATRIX_MVP, float4(v.normal, 0.0));
+	float width = _OutlineWidth / 1024.0; //目コピ調整値(算術根拠無し)
+	float depth_offset = pos.z / 4194304.0; //僅かに奥に移動(floatの仮数部は23bitなので(1<<21)程度で割った値は丸めに入らないが非常に小さな値の筈)
+	o.pos = pos + normal * float4(width, width, 0.0, 0.0) + float4(0.0, 0.0, depth_offset, 0.0);
 
 	return o;
 }
 half4 frag( v2f i ) : COLOR
 {
-	return half4( _OutlineColor.rgb, _Opacity );
+	return half4( _OutlineColor.rgb, _OutlineColor.a * _Opacity );
 }


### PR DESCRIPTION
画角やスケールに依ってエッジ幅が変わる不具合を修正しました。
それに伴い、旧エッジ幅を元に調整されていた定数等は削除・再設定しています。
これでエッジが妙に太く表示されるのは改善されたかと思います。

エッジにエッジ不透明度が反映されていない不具合を修正しました。

エディタ時に於けるエッジ幅のリアルタイム変更に対応しました。
Start()に有ったエッジ幅設定を全面的にInspecotre側に移動しました。
副作用として、同一プレファブのモデルを複数表示しているとエッジ幅が共有されてしまいます。
メッシュが共有されていた時の解決策と同様の事をすれば分離出来るのですが、しませんでした(単に手抜きです)。
MMDEngineのShaderListも共有に為っている事に気付いたので、分けた方が良いかもしれませんね。
### テストモデル
- あにまさ式初音ミク(MMD Ver.8.03(x64)付属)
- Lat式ミク(Ver2.3)
- Tda式初音ミク・アペンド(Ver1.00)
