### PR TITLE
透過ピクセルは描画しない様に修正

### DIFF
--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans-CullBack-NoCastShadow.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans-CullBack-NoCastShadow.shader
@@ -43,6 +43,7 @@ Shader "MMD/Transparent/PMDMaterial-CullBack-NoCastShadow"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans-CullBack.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans-CullBack.shader
@@ -43,6 +43,7 @@ Shader "MMD/Transparent/PMDMaterial-CullBack"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -58,6 +59,14 @@ Shader "MMD/Transparent/PMDMaterial-CullBack"
 			Cull Off
 			Lighting Off
 			//Offset [_ShadowBias], [_ShadowBiasSlope] //使えない様なのでコメントアウト
+			AlphaTest Greater 0.25
+			
+			CGPROGRAM
+			#pragma vertex shadow_vert
+			#pragma fragment shadow_frag
+			#include "UnityCG.cginc"
+			#include "MeshPmdMaterialShadowVertFrag.cginc"
+			ENDCG
 		}
 
 	}

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans-NoCastShadow.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans-NoCastShadow.shader
@@ -43,6 +43,7 @@ Shader "MMD/Transparent/PMDMaterial-NoCastShadow"
 		Cull Front
 		ZWrite Off
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -52,6 +53,7 @@ Shader "MMD/Transparent/PMDMaterial-NoCastShadow"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterial-Trans.shader
@@ -43,6 +43,7 @@ Shader "MMD/Transparent/PMDMaterial"
 		Cull Front
 		ZWrite Off
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -52,6 +53,7 @@ Shader "MMD/Transparent/PMDMaterial"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -67,6 +69,14 @@ Shader "MMD/Transparent/PMDMaterial"
 			Cull Off
 			Lighting Off
 			//Offset [_ShadowBias], [_ShadowBiasSlope] //使えない様なのでコメントアウト
+			AlphaTest Greater 0.25
+			
+			CGPROGRAM
+			#pragma vertex shadow_vert
+			#pragma fragment shadow_frag
+			#include "UnityCG.cginc"
+			#include "MeshPmdMaterialShadowVertFrag.cginc"
+			ENDCG
 		}
 
 	}

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans-CullBack-NoCastShadow.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans-CullBack-NoCastShadow.shader
@@ -46,6 +46,7 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline-CullBack-NoCastShadow"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans-CullBack.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans-CullBack.shader
@@ -46,6 +46,7 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline-CullBack"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -74,6 +75,14 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline-CullBack"
 			Cull Off
 			Lighting Off
 			//Offset [_ShadowBias], [_ShadowBiasSlope] //使えない様なのでコメントアウト
+			AlphaTest Greater 0.25
+			
+			CGPROGRAM
+			#pragma vertex shadow_vert
+			#pragma fragment shadow_frag
+			#include "UnityCG.cginc"
+			#include "MeshPmdMaterialShadowVertFrag.cginc"
+			ENDCG
 		}
 	
 	}

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans-NoCastShadow.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans-NoCastShadow.shader
@@ -45,6 +45,7 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline-NoCastShadow"
 		Cull Front
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -54,6 +55,7 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline-NoCastShadow"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans.shader
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterialOutline-Trans.shader
@@ -46,6 +46,7 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline"
 		Cull Front
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -55,6 +56,7 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline"
 		Cull Back
 		ZWrite On
 		Blend SrcAlpha OneMinusSrcAlpha
+		AlphaTest Greater 0.0
 		CGPROGRAM
 		#pragma surface surf MMD
 		#include "MeshPmdMaterialSurface.cginc"
@@ -83,6 +85,14 @@ Shader "MMD/Transparent/PMDMaterial-with-Outline"
 			Cull Off
 			Lighting Off
 			//Offset [_ShadowBias], [_ShadowBiasSlope] //使えない様なのでコメントアウト
+			AlphaTest Greater 0.25
+			
+			CGPROGRAM
+			#pragma vertex shadow_vert
+			#pragma fragment shadow_frag
+			#include "UnityCG.cginc"
+			#include "MeshPmdMaterialShadowVertFrag.cginc"
+			ENDCG
 		}
 	
 	}

--- a/Resources/PMDMaterial/Shaders/MeshPmdMaterialShadowVertFrag.cginc
+++ b/Resources/PMDMaterial/Shaders/MeshPmdMaterialShadowVertFrag.cginc
@@ -1,0 +1,40 @@
+/*
+ * MMD Shader for Unity
+ *
+ * Copyright 2012 Masataka SUMI, Takahiro INOUE
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+float _Opacity;
+sampler2D _MainTex;
+float4 _MainTex_ST;
+
+struct v2f
+{
+	float4 pos : SV_POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+v2f shadow_vert( appdata_img v )
+{
+	v2f o;
+	o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
+	return o;
+}
+
+half4 shadow_frag( v2f i ) : COLOR
+{
+	float4 tex_color = tex2D(_MainTex, i.uv);
+	return half4(0, 0, 0, tex_color.a * _Opacity);
+}


### PR DESCRIPTION
透過(α値が0.0)なピクセルは描画しない様に修正しました。

羽有りula式トゥイードル・ダムさんを正面から見ると、羽が武器の形で切り取られる不具合が修正されます。
合わせて羽や武器を表示していない時でも影が落ちてしまう不具合も修正されます。
### テストモデル
- あにまさ式初音ミク(MMD Ver.8.03(x64)付属)
- Lat式ミク(Ver2.3)
- mqdl式初音ミクXS(rev.c)
- Tda式初音ミク・アペンド(Ver1.00)
- ula式トゥイードル・ダム(Ver.1.00)
- ula式トゥイードル・ディー(Ver.1.00)
