### PR TITLE
AvatarSettingScript:腕水平化に於いて、間接が正しく選択されない場合がある不具合の修正

### DIFF
--- a/Editor/MMDLoader/Private/AvatarSettingScript.cs
+++ b/Editor/MMDLoader/Private/AvatarSettingScript.cs
@@ -178,8 +178,7 @@ public class AvatarSettingScript
 	/// <returns>true:ボーンが存在する, false:ボーンが存在しない</returns>
 	/// <param name='name'>ボーン名</param>
 	bool HasBone(string name) {
-		int count = bones_.Where(x=>x.name == name).Count();
-		return 0 < count;
+		return bones_.Any(x=>x.name == name);
 	}
 
 	/// <summary>


### PR DESCRIPTION
肩・腕・ひじ・手首がそれぞれの直下に無い場合に、間接ボーンの探索に失敗する不具合を修正しました。
Tda式初音ミク・アペンドさんの様な捩りボーンやキャンセルボーンが組み込まれているモデルにてTポーズに正しく変形されない不具合が修正されます。
# テストモデル
- あにまさ式初音ミク(MMD Ver.8.03(x64)付属) _(腰ボーンを認識してない)_
- Lat式ミク(Ver2.3) _(腰ボーンを認識してない)_
- mqdl式初音ミクXS(rev.c)
- えと式初音ミク(ver3.01β)
- Tda式初音ミク・アペンド(Ver1.00)
- おんだ式初音ミク(Ver.1.50)
- ままま式GUMIβ V3 Whisper ver (2013/06/03版)
- ula式巡音ルカ(Ver3.11)

[Mecanim Locomotion Starter Kit](http://u3d.as/content/unity-technologies/mecanim-locomotion-starter-kit/4jU)が正常動作するかで判断しています。
