### PR TITLE
AvatarSettingScript:全ての親ボーンと腰ボーンが無いモデルでMecanimがおかしい不具合の修正

### DIFF
--- a/Editor/MMDLoader/Private/AvatarSettingScript.cs
+++ b/Editor/MMDLoader/Private/AvatarSettingScript.cs
@@ -287,15 +287,32 @@ public class AvatarSettingScript
 	/// <returns>スケルトンボーン</returns>
 	SkeletonBone[] CreateSkeletonBone()
 	{
-		return bones_.Select(x=>{
-								SkeletonBone skeleton_bone = new SkeletonBone();
-								skeleton_bone.name = x.name;
-								Transform transform = x.transform;
-								skeleton_bone.position = transform.localPosition;
-								skeleton_bone.rotation = transform.localRotation;
-								skeleton_bone.scale = transform.localScale;
-								return skeleton_bone;
-							}).ToArray();
+		IEnumerable<GameObject> bones_enumerator = bones_;
+
+		//Hipsボーンの親ボーン迄SkeletonBoneに入れる必要が有るので、確認と追加
+		string hips_bone_name = ((HasBone("腰"))? "腰": "センター");
+		Transform hips_parent_bone = bones_.Where(x=>x.name == hips_bone_name).Select(x=>x.transform.parent).FirstOrDefault();
+		if (null != hips_parent_bone) {
+			//Hipsボーンの親ボーンが有るなら
+			//Hipsボーンの親ボーンがbones_に含まれているか確認する
+			if (!HasBone(hips_parent_bone.name)) {
+				//Hipsボーンの親ボーンがbones_に無いなら
+				//追加(Hipsボーン依りも前に追加しないといけないので注意)
+				bones_enumerator = Enumerable.Repeat(hips_parent_bone.gameObject, 1)
+											.Concat(bones_enumerator);
+			}
+		}
+
+		var result = bones_enumerator.Select(x=>{
+												SkeletonBone skeleton_bone = new SkeletonBone();
+												skeleton_bone.name = x.name;
+												Transform transform = x.transform;
+												skeleton_bone.position = transform.localPosition;
+												skeleton_bone.rotation = transform.localRotation;
+												skeleton_bone.scale = transform.localScale;
+												return skeleton_bone;
+											});
+		return result.ToArray();
 	}
 
 	/// <summary>


### PR DESCRIPTION
全ての親ボーンと腰ボーンが無いモデルに於いて、Avatarの情報が人型を保っていない不具合を修正しました。
あにまさ式初音ミクさんとLat式ミクさんにHumanoidAvatar形式のモーションが正しく適応されない不具合が修正されます。
# テストモデル
- あにまさ式初音ミク(MMD Ver.8.03(x64)付属)
- Lat式ミク(Ver2.3)
- mqdl式初音ミクXS(rev.c)
- えと式初音ミク(ver3.01β) _(腕がTポーズを取らない)_
- Tda式初音ミク・アペンド(Ver1.00) _(腕がTポーズを取らない)_
- おんだ式初音ミク(Ver.1.50)
- ままま式GUMIβ V3 Whisper ver (2013/06/03版) _(腕がTポーズを取らない)_
- ula式巡音ルカ(Ver3.11)

[Mecanim Locomotion Starter Kit](http://u3d.as/content/unity-technologies/mecanim-locomotion-starter-kit/4jU)が正常動作するかで判断しています。
テストモデル確認時に #31 は当たっていません。
