### PR TITLE
汎用アバター対応

### DIFF
--- a/Editor/Config/Config.cs
+++ b/Editor/Config/Config.cs
@@ -113,7 +113,7 @@ namespace MMD
     public class DefaultPMDImportConfig : ConfigBase
     {
         public PMDConverter.ShaderType shader_type = PMDConverter.ShaderType.MMDShader;
-        public bool use_mecanim = false;
+        public PMXConverter.AnimationType animation_type = PMXConverter.AnimationType.LegacyAnimation;
         public bool rigidFlag = true;
         public bool use_ik = true;
         public float scale = 0.085f;
@@ -130,7 +130,7 @@ namespace MMD
                 {
                     shader_type = (PMDConverter.ShaderType)EditorGUILayout.EnumPopup("Shader Type", shader_type);
                     rigidFlag = EditorGUILayout.Toggle("Rigidbody", rigidFlag);
-					use_mecanim = EditorGUILayout.Toggle("Use Mecanim", use_mecanim);	// ここfalseになってたけど理由があるのかわからない
+                    animation_type = (PMXConverter.AnimationType)EditorGUILayout.EnumPopup("Animation Type", animation_type);
                     use_ik = EditorGUILayout.Toggle("Use IK", use_ik);
                     is_pmx_base_import = EditorGUILayout.Toggle("Use PMX Base Import", is_pmx_base_import);
                 }

--- a/Editor/Inspector/PMDInspector.cs
+++ b/Editor/Inspector/PMDInspector.cs
@@ -12,7 +12,7 @@ namespace MMD
         // PMD Load option
         public PMDConverter.ShaderType shader_type;
         public bool rigidFlag;
-        public bool use_mecanim;
+        public PMXConverter.AnimationType animation_type;
         public bool use_ik;
         public float scale;
         public bool is_pmx_base_import;
@@ -30,7 +30,7 @@ namespace MMD
 			var config = MMD.Config.LoadAndCreate();
             shader_type = config.pmd_config.shader_type;
             rigidFlag = config.pmd_config.rigidFlag;
-            use_mecanim = config.pmd_config.use_mecanim;
+            animation_type = config.pmd_config.animation_type;
             use_ik = config.pmd_config.use_ik;
             scale = config.pmd_config.scale;
             is_pmx_base_import = config.pmd_config.is_pmx_base_import;
@@ -64,7 +64,7 @@ namespace MMD
             rigidFlag = EditorGUILayout.Toggle("Rigidbody", rigidFlag);
 
             // Mecanimを使うかどうか
-            use_mecanim = EditorGUILayout.Toggle("Use Mecanim", use_mecanim);
+            animation_type = (PMXConverter.AnimationType)EditorGUILayout.EnumPopup("Animation Type", animation_type);
 
             // IKを使うかどうか
             use_ik = EditorGUILayout.Toggle("Use IK", use_ik);
@@ -100,7 +100,7 @@ namespace MMD
 						var obj = (PMDScriptableObject)target;
                         model_agent = new ModelAgent(obj.assetPath);
                     }
-                    model_agent.CreatePrefab(shader_type, rigidFlag, use_mecanim, use_ik, scale, is_pmx_base_import);
+                    model_agent.CreatePrefab(shader_type, rigidFlag, animation_type, use_ik, scale, is_pmx_base_import);
                     message = "Loading done.";
                 }
             }

--- a/Editor/MMDLoader/PMDLoaderWindow.cs
+++ b/Editor/MMDLoader/PMDLoaderWindow.cs
@@ -1,11 +1,11 @@
-using UnityEngine;
+﻿using UnityEngine;
 using System.Collections;
 using UnityEditor;
 
 public class PMDLoaderWindow : EditorWindow {
 	Object pmdFile = null;
 	bool rigidFlag = true;
-	bool use_mecanim = false;
+	MMD.PMXConverter.AnimationType animation_type = MMD.PMXConverter.AnimationType.LegacyAnimation;
 	MMD.PMDConverter.ShaderType shader_type = MMD.PMDConverter.ShaderType.MMDShader;
 
 	bool use_ik = true;
@@ -13,33 +13,33 @@ public class PMDLoaderWindow : EditorWindow {
 	bool is_pmx_base_import = false;
 
 	[MenuItem("MMD for Unity/PMD Loader")]
-	static void Init() {        
-        var window = (PMDLoaderWindow)EditorWindow.GetWindow<PMDLoaderWindow>(true, "PMDLoader");
+	static void Init() {
+		var window = (PMDLoaderWindow)EditorWindow.GetWindow<PMDLoaderWindow>(true, "PMDLoader");
 		window.Show();
 	}
 
-    public PMDLoaderWindow()
-    {
-        // デフォルトコンフィグ
+	public PMDLoaderWindow()
+	{
+		// デフォルトコンフィグ
 		var config = MMD.Config.LoadAndCreate();
 		shader_type = config.pmd_config.shader_type;
 		rigidFlag = config.pmd_config.rigidFlag;
-		use_mecanim = config.pmd_config.use_mecanim;
+		animation_type = config.pmd_config.animation_type;
 		use_ik = config.pmd_config.use_ik;
 		is_pmx_base_import = config.pmd_config.is_pmx_base_import;
-    }
+	}
 	
 	void OnGUI() {
 		pmdFile = EditorGUILayout.ObjectField("PMD File" , pmdFile, typeof(Object), false);
 		
 		// シェーダの種類
-		shader_type = (PMDConverter.ShaderType)EditorGUILayout.EnumPopup("Shader Type", shader_type);
+		shader_type = (MMD.PMDConverter.ShaderType)EditorGUILayout.EnumPopup("Shader Type", shader_type);
 
 		// 剛体を入れるかどうか
 		rigidFlag = EditorGUILayout.Toggle("Rigidbody", rigidFlag);
 
-		// Mecanimを使うかどうか
-		use_mecanim = EditorGUILayout.Toggle("Use Mecanim", use_mecanim);
+		// アニメーションタイプ
+		animation_type = (MMD.PMXConverter.AnimationType)EditorGUILayout.EnumPopup("Animation Type", animation_type);
 
 		// IKを使うかどうか
 		use_ik = EditorGUILayout.Toggle("Use IK", use_ik);
@@ -74,7 +74,7 @@ public class PMDLoaderWindow : EditorWindow {
 	void LoadModel() {
 		string file_path = AssetDatabase.GetAssetPath(pmdFile);
 		MMD.ModelAgent model_agent = new MMD.ModelAgent(file_path);
-		model_agent.CreatePrefab(shader_type, rigidFlag, use_mecanim, use_ik, scale, is_pmx_base_import);
+		model_agent.CreatePrefab(shader_type, rigidFlag, animation_type, use_ik, scale, is_pmx_base_import);
 		
 		// 読み込み完了メッセージ
 		var window = LoadedWindow.Init();

--- a/Editor/MMDLoader/Private/AvatarSettingScript.cs
+++ b/Editor/MMDLoader/Private/AvatarSettingScript.cs
@@ -18,15 +18,37 @@ public class AvatarSettingScript
 	}
 
 	/// <summary>
-	/// アバダーを設定する
+	/// 汎用アバダーを設定する
 	/// </summary>
 	/// <returns>アニメーター</returns>
-	/// <param name='root_game_object'>ルートゲームオブジェクト</param>
-	/// <param name='bones'>ボーンのゲームオブジェクト</param>
+	public Animator SettingGenericAvatar() {
+		//アバタールートトランスフォームの取得
+		Transform avatar_root_transform = root_game_object_.transform.FindChild("Model");
+		if (null == avatar_root_transform) {
+			//ルートゲームオブジェクト直下にモデルルートオブジェクトが無い(PMDConverter)なら
+			//ルートゲームオブジェクトをアバタールートオブジェクトとする
+			avatar_root_transform = root_game_object_.transform;
+		}
+		
+		//ジェネリックアバター作成
+		string root_name = ((HasBone("全ての親"))? "全ての親": "");
+		avatar_ = AvatarBuilder.BuildGenericAvatar(avatar_root_transform.gameObject, root_name);
+		
+		//アバターをアニメーターに設定
+		animator_ = root_game_object_.AddComponent<Animator>();
+		animator_.avatar = avatar_;
+		
+		return animator_;
+	}
+
+	/// <summary>
+	/// 人型アバダーを設定する
+	/// </summary>
+	/// <returns>アニメーター</returns>
 	/// <remarks>
 	/// モデルに依ってボーン構成に差が有るが、MMD標準モデルとの一致を優先する
 	/// </remarks>
-	public Animator SettingAvatar() {
+	public Animator SettingHumanAvatar() {
 		//生成済みのボーンをUnity推奨ポーズに設定
 		SetRequirePose();
 		

--- a/Editor/MMDLoader/Private/ModelAgent.cs
+++ b/Editor/MMDLoader/Private/ModelAgent.cs
@@ -32,11 +32,11 @@ namespace MMD {
 		/// </summary>
 		/// <param name='shader_type'>シェーダーの種類</param>
 		/// <param name='use_rigidbody'>剛体を使用するか</param>
-		/// <param name='use_mecanim'>Mecanimを使用するか</param>
+		/// <param name='animation_type'>アニメーションタイプ</param>
 		/// <param name='use_ik'>IKを使用するか</param>
 		/// <param name='scale'>スケール</param>
 		/// <param name='is_pmx_base_import'>PMX Baseでインポートするか</param>
-		public void CreatePrefab(PMDConverter.ShaderType shader_type, bool use_rigidbody, bool use_mecanim, bool use_ik, float scale, bool is_pmx_base_import) {
+		public void CreatePrefab(PMDConverter.ShaderType shader_type, bool use_rigidbody, PMXConverter.AnimationType animation_type, bool use_ik, float scale, bool is_pmx_base_import) {
 			GameObject game_object;
 			string prefab_path;
 			if (is_pmx_base_import) {
@@ -54,7 +54,7 @@ namespace MMD {
 				}
 				header_ = pmx_format.header;
 				//ゲームオブジェクトの作成
-				game_object = PMXConverter.CreateGameObject(pmx_format, use_rigidbody, use_mecanim, use_ik, scale);
+				game_object = PMXConverter.CreateGameObject(pmx_format, use_rigidbody, animation_type, use_ik, scale);
 	
 				// プレファブパスの設定
 				prefab_path = pmx_format.meta_header.folder + "/" + pmx_format.meta_header.name + ".prefab";
@@ -74,6 +74,7 @@ namespace MMD {
 				header_ = PMXLoaderScript.PMD2PMX(pmd_format.head);
 	
 				//ゲームオブジェクトの作成
+				bool use_mecanim = PMXConverter.AnimationType.LegacyAnimation == animation_type;
 				game_object = PMDConverter.CreateGameObject(pmd_format, shader_type, use_rigidbody, use_mecanim, use_ik, scale);
 	
 				// プレファブパスの設定

--- a/Editor/MMDLoader/Private/PMDConverter.cs
+++ b/Editor/MMDLoader/Private/PMDConverter.cs
@@ -89,7 +89,7 @@ namespace MMD
 			// Mecanim設定
 			if (use_mecanim_) {
 				AvatarSettingScript avatar_setting = new AvatarSettingScript(root_game_object_, bones);
-				avatar_setting.SettingAvatar();
+				avatar_setting.SettingHumanAvatar();
 				
 				string path = format_.folder + "/";
 				string name = GetFilePathString(format_.name);

--- a/Editor/MMDLoader/Private/VMDConverter.cs
+++ b/Editor/MMDLoader/Private/VMDConverter.cs
@@ -53,6 +53,8 @@ namespace MMD
 
 			CreateKeysForSkin(format, clip);	// 表情の追加
 			
+			SetAnimationType(clip, assign_pmd); //アニメーションタイプの設定
+			
 			return clip;
 		}
 
@@ -535,6 +537,25 @@ namespace MMD
 			}
 		}
 
+		/// <summary>
+		/// アニメーションタイプの設定
+		/// </summary>
+		/// <param name="clip">設定するアニメーションクリップ.</param>
+		/// <param name="engine">設定の為に参照するAnimatorを持つゲームオブジェクト</param>
+		static void SetAnimationType(AnimationClip clip, GameObject game_object)
+		{
+			ModelImporterAnimationType animation_type;
+			Animator animator = game_object.GetComponent<Animator>();
+			if (null == animator) {
+				animation_type = ModelImporterAnimationType.Legacy;
+			} else if ((null == animator.avatar) && animator.avatar.isHuman) {
+				animation_type = ModelImporterAnimationType.Human;
+			} else {
+				animation_type = ModelImporterAnimationType.Generic;
+			}
+			AnimationUtility.SetAnimationType(clip, animation_type);
+		}
+		
 		private float scale_ = 1.0f;
 	}
 }


### PR DESCRIPTION
汎用アバター形式のMecanimに対応しました(モーション含む)。
なお汎用アバター生成はPMXConverter.csしか組み込んでいないので「Use PMX Base Import」オプション必須と為ります。
# テストモデル・モーション
- あにまさ式初音ミク(MMD Ver.8.03(x64)付属)
- Lat式ミク(Ver2.31)
- Tda式初音ミク・アペンド(Ver1.00)
- おんだ式初音ミク(Ver.1.50)
- hino式WAVEFILE fullver.モーション

「Use PMX Base Import」はオンでの確認です。
