### PR TITLE
変換UI周りの調整

### DIFF
--- a/Editor/Config/ConfigWindow.cs
+++ b/Editor/Config/ConfigWindow.cs
@@ -5,8 +5,7 @@ namespace MMD
 {
     public class ConfigWindow : EditorWindow
     {
-        private static Config config;
-        private static string path;
+        private Config config;
 
         [MenuItem("MMD for Unity/Config")]
         public static void Init()
@@ -18,36 +17,18 @@ namespace MMD
         //   フォーカスが外れて戻ってきたときや再度開かれたときなど
         void OnEnable()
         {
-            // オブジェクトを「Hierarchy」に表示しない。また、アセットの中にあれば、プロジェクトビューに表示しない
-            // オブジェクトがシーンに保存されない。また、新しいシーンを読んでも、オブジェクトが破棄されない
-            hideFlags = HideFlags.HideAndDontSave;
-
             if (config == null)
             {
                 // 読み込む
                 config = MMD.Config.LoadAndCreate();
-
-                // なかったら作成する
-                if (config == null)
-                {
-                    path = MMD.Config.GetConfigPath();
-                    config = CreateInstance<Config>();
-                    AssetDatabase.CreateAsset(config, path);
-                    EditorUtility.SetDirty(config);
-                }
             }
         }
 
         // ウィンドウの描画処理
         void OnGUI()
         {
-            // たいとる
-            EditorGUILayout.LabelField("MMD for Unity Configuration");
-            EditorGUILayout.Space();
-
             // あとは任せる
             config.OnGUI();
-
         }
     }
 }

--- a/Editor/Inspector/InspectorBase.cs
+++ b/Editor/Inspector/InspectorBase.cs
@@ -12,32 +12,43 @@ using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
 
-#if !(UNITY_3_5 || UNITY_3_4 || UNITY_3_3)
-
 namespace MMD
 {
-    public class InspectorBase : Editor
-    {
+	[InitializeOnLoad]
+	public class InspectorBase : Editor
+	{
+		static InspectorBase()
+		{
+			EntryEditorApplicationUpdate();
+		}
+
 		[DidReloadScripts]
 		static void OnDidReloadScripts()
 		{
-			EditorApplication.update += () =>
-			{
-				if (Selection.objects.Length != 0)
-				{
-					string path = AssetDatabase.GetAssetPath(Selection.activeObject);
-					string extension = Path.GetExtension(path).ToLower();
+			EntryEditorApplicationUpdate();
+		}
 
-					if (extension == ".pmd" || extension == ".pmx")
-					{
-						SetupScriptableObject<PMDScriptableObject>(path);
-					}
-					else if (extension == ".vmd")
-					{
-						SetupScriptableObject<VMDScriptableObject>(path);
-					}
+		static void EntryEditorApplicationUpdate()
+		{
+			EditorApplication.update += Update;
+		}
+
+		static void Update()
+		{
+			if (Selection.objects.Length != 0)
+			{
+				string path = AssetDatabase.GetAssetPath(Selection.activeObject);
+				string extension = Path.GetExtension(path).ToLower();
+
+				if (extension == ".pmd" || extension == ".pmx")
+				{
+					SetupScriptableObject<PMDScriptableObject>(path);
 				}
-			};
+				else if (extension == ".vmd")
+				{
+					SetupScriptableObject<VMDScriptableObject>(path);
+				}
+			}
 		}
 
 		static void SetupScriptableObject<T>(string path) where T : ScriptableObjectBase
@@ -49,8 +60,7 @@ namespace MMD
 			Selection.activeObject = scriptableObject;
 			EditorUtility.UnloadUnusedAssets();
 		}
-    }
+	}
 }
 
-#endif
 #endif

--- a/Editor/Inspector/VMDInspector.cs
+++ b/Editor/Inspector/VMDInspector.cs
@@ -4,37 +4,32 @@ using System.Collections;
 using MMD.PMD;
 using System.IO;
 
-#if !(UNITY_3_5 || UNITY_3_4 || UNITY_3_3)
-
 namespace MMD
 {
-	[CustomEditor(typeof(VMDScriptableObject))]
+    [CustomEditor(typeof(VMDScriptableObject))]
     public class VMDInspector : Editor
     {
         // VMD Load option
-        public bool createAnimationFile;
-        public int interpolationQuality;
         public GameObject pmdPrefab;
+        VMDImportConfig vmd_config;
 
         // last selected item
-        private static MotionAgent motion_agent;
-        private static string message = "";
+        private MotionAgent motion_agent;
+        private string message = "";
 
         /// <summary>
-        /// 選択されているオブジェクトがVMDファイルかチェックします
+        /// 有効化処理
         /// </summary>
-        /// <returns>VMDファイルであればそのパスを、異なればnullを返します。</returns>
-        void setup()
+        void OnEnable()
         {
             // デフォルトコンフィグ
             var config = MMD.Config.LoadAndCreate();
-            createAnimationFile = config.vmd_config.createAnimationFile;
-            interpolationQuality = config.vmd_config.interpolationQuality;
+            vmd_config = config.vmd_config.Clone();
 
             // モデル情報
             if (config.inspector_config.use_vmd_preload)
             {
-				var obj = (VMDScriptableObject)target;
+                var obj = (VMDScriptableObject)target;
                 motion_agent = new MotionAgent(obj.assetPath);
             }
             else
@@ -48,14 +43,11 @@ namespace MMD
         /// </summary>
         public override void OnInspectorGUI()
         {
-            setup();
-
             // GUIの有効化
-            GUI.enabled = true;
+            GUI.enabled = !EditorApplication.isPlaying;
 
-            pmdPrefab = EditorGUILayout.ObjectField("PMD Prefab", pmdPrefab, typeof(Object), false) as GameObject;
-            createAnimationFile = EditorGUILayout.Toggle("Create Asset", createAnimationFile);
-            interpolationQuality = EditorGUILayout.IntSlider("Interpolation Quality", interpolationQuality, 1, 10);
+            pmdPrefab = (GameObject)EditorGUILayout.ObjectField("PMD Prefab", pmdPrefab, typeof(Object), false);
+            vmd_config.OnGUIFunction();
 
             // Convertボタン
             EditorGUILayout.Space();
@@ -65,25 +57,28 @@ namespace MMD
             }
             else
             {
+                bool gui_enabled_old = GUI.enabled;
+                GUI.enabled = (null != pmdPrefab);
                 if (GUILayout.Button("Convert"))
                 {
                     if (null == motion_agent) {
-						var obj = (VMDScriptableObject)target;
+                        var obj = (VMDScriptableObject)target;
                         motion_agent = new MotionAgent(obj.assetPath);
                     }
-                    motion_agent.CreateAnimationClip(pmdPrefab, createAnimationFile, interpolationQuality);
+                    motion_agent.CreateAnimationClip(pmdPrefab
+                                                    , vmd_config.createAnimationFile
+                                                    , vmd_config.interpolationQuality
+                                                    );
                     message = "Loading done.";
                 }
+                GUI.enabled = gui_enabled_old;
             }
             GUILayout.Space(40);
 
             // モデル情報
             if (motion_agent == null) return;
             EditorGUILayout.LabelField("Model Name");
-            GUI.enabled = false;
-            EditorGUILayout.TextArea(motion_agent.model_name);
-            GUI.enabled = true;
+            EditorGUILayout.LabelField(motion_agent.model_name, EditorStyles.textField);
         }
     }
 }
-#endif

--- a/Editor/MMDLoader/PMDLoaderWindow.cs
+++ b/Editor/MMDLoader/PMDLoaderWindow.cs
@@ -3,14 +3,8 @@ using System.Collections;
 using UnityEditor;
 
 public class PMDLoaderWindow : EditorWindow {
-	Object pmdFile = null;
-	bool rigidFlag = true;
-	MMD.PMXConverter.AnimationType animation_type = MMD.PMXConverter.AnimationType.LegacyAnimation;
-	MMD.PMDConverter.ShaderType shader_type = MMD.PMDConverter.ShaderType.MMDShader;
-
-	bool use_ik = true;
-	float scale = 0.085f;
-	bool is_pmx_base_import = false;
+	Object pmdFile;
+	MMD.PMDImportConfig pmd_config;
 
 	[MenuItem("MMD for Unity/PMD Loader")]
 	static void Init() {
@@ -18,63 +12,42 @@ public class PMDLoaderWindow : EditorWindow {
 		window.Show();
 	}
 
-	public PMDLoaderWindow()
+	void OnEnable()
 	{
 		// デフォルトコンフィグ
-		var config = MMD.Config.LoadAndCreate();
-		shader_type = config.pmd_config.shader_type;
-		rigidFlag = config.pmd_config.rigidFlag;
-		animation_type = config.pmd_config.animation_type;
-		use_ik = config.pmd_config.use_ik;
-		is_pmx_base_import = config.pmd_config.is_pmx_base_import;
+		pmdFile = null;
+		pmd_config = MMD.Config.LoadAndCreate().pmd_config.Clone();
 	}
 	
 	void OnGUI() {
+		// GUIの有効化
+		GUI.enabled = !EditorApplication.isPlaying;
+		
+		// GUI描画
 		pmdFile = EditorGUILayout.ObjectField("PMD File" , pmdFile, typeof(Object), false);
+		pmd_config.OnGUIFunction();
 		
-		// シェーダの種類
-		shader_type = (MMD.PMDConverter.ShaderType)EditorGUILayout.EnumPopup("Shader Type", shader_type);
-
-		// 剛体を入れるかどうか
-		rigidFlag = EditorGUILayout.Toggle("Rigidbody", rigidFlag);
-
-		// アニメーションタイプ
-		animation_type = (MMD.PMXConverter.AnimationType)EditorGUILayout.EnumPopup("Animation Type", animation_type);
-
-		// IKを使うかどうか
-		use_ik = EditorGUILayout.Toggle("Use IK", use_ik);
-
-		// スケール
-		scale = EditorGUILayout.Slider("Scale", scale, 0.001f, 1.0f);
-		EditorGUILayout.BeginHorizontal();
 		{
-			EditorGUILayout.PrefixLabel(" ");
-			if (GUILayout.Button("Original", EditorStyles.miniButtonLeft)) {
-				scale = 0.085f;
-			}
-			if (GUILayout.Button("1.0", EditorStyles.miniButtonRight)) {
-				scale = 1.0f;
-			}
-		}
-		EditorGUILayout.EndHorizontal();
-
-		// PMX Baseでインポートするかどうか
-		is_pmx_base_import = EditorGUILayout.Toggle("Use PMX Base Import", is_pmx_base_import);
-		
-		if (pmdFile != null) {
+			bool gui_enabled_old = GUI.enabled;
+			GUI.enabled = !EditorApplication.isPlaying && (pmdFile != null);
 			if (GUILayout.Button("Convert")) {
 				LoadModel();
 				pmdFile = null;		// 読み終わったので空にする 
 			}
-		} else {
-			EditorGUILayout.LabelField("Missing", "Select PMD File");
+			GUI.enabled = gui_enabled_old;
 		}
 	}
 
 	void LoadModel() {
 		string file_path = AssetDatabase.GetAssetPath(pmdFile);
 		MMD.ModelAgent model_agent = new MMD.ModelAgent(file_path);
-		model_agent.CreatePrefab(shader_type, rigidFlag, animation_type, use_ik, scale, is_pmx_base_import);
+		model_agent.CreatePrefab(pmd_config.shader_type
+								, pmd_config.rigidFlag
+								, pmd_config.animation_type
+								, pmd_config.use_ik
+								, pmd_config.scale
+								, pmd_config.is_pmx_base_import
+								);
 		
 		// 読み込み完了メッセージ
 		var window = LoadedWindow.Init();

--- a/Editor/MMDLoader/VMDLoaderWindow.cs
+++ b/Editor/MMDLoader/VMDLoaderWindow.cs
@@ -5,8 +5,7 @@ using UnityEditor;
 public class VMDLoaderWindow : EditorWindow {
 	Object vmdFile;
 	GameObject pmdPrefab;
-	bool createAnimationFile;
-	int interpolationQuality;
+	MMD.VMDImportConfig vmd_config;
 
 	[MenuItem ("MMD for Unity/VMD Loader")]
 	static void Init() {
@@ -14,56 +13,40 @@ public class VMDLoaderWindow : EditorWindow {
 		window.Show();
 	}
 	
-    public VMDLoaderWindow()
-    {
-        // デフォルトコンフィグ
-        var config = MMD.Config.LoadAndCreate();
-        createAnimationFile = config.vmd_config.createAnimationFile;
-        interpolationQuality = config.vmd_config.interpolationQuality;
-    }
+	void OnEnable()
+	{
+		// デフォルトコンフィグ
+		vmdFile = null;
+		pmdPrefab = null;
+		vmd_config = MMD.Config.LoadAndCreate().vmd_config.Clone();
+	}
 
     void OnGUI() {
-		const int height = 20;
-		int top = 0;
+		// GUIの有効化
+		GUI.enabled = !EditorApplication.isPlaying;
 		
-		pmdPrefab = EditorGUI.ObjectField(
-			new Rect(0, top, position.width - 16, height), "PMD Prefab", pmdPrefab, typeof(GameObject), false) as GameObject;
-		top += height + 2;
-		
-		vmdFile = EditorGUI.ObjectField(
-			new Rect(0, top, position.width - 16, height), "VMD File", vmdFile, typeof(Object), false);
-		top += height + 2;
-		
- 		createAnimationFile = EditorGUI.Toggle(
-			new Rect(0, top, position.width - 16, height), "Create Asset", createAnimationFile);
-		top += height + 2;
+		// GUI描画
+		pmdPrefab = (GameObject)EditorGUILayout.ObjectField("PMD Prefab", pmdPrefab, typeof(GameObject), false);
+		vmdFile = EditorGUILayout.ObjectField("VMD File", vmdFile, typeof(Object), false);
+		vmd_config.OnGUIFunction();
 
-		interpolationQuality=EditorGUI.IntSlider (
-			new Rect(0, top, position.width - 16, height), "Interpolation Quality", interpolationQuality, 1, 10);
-		top += height + 2;		
-
-		if (pmdPrefab != null && vmdFile != null) 
 		{
-			if (GUI.Button(new Rect(0, top, position.width / 2, 16), "Convert"))
-			{
+			bool gui_enabled_old = GUI.enabled;
+			GUI.enabled = !EditorApplication.isPlaying && (pmdPrefab != null) && (vmdFile != null);
+			if (GUILayout.Button("Convert")) {
 				LoadMotion();
 				vmdFile = null;
 			}
-		} 
-		else 
-		{
-			if (pmdPrefab == null)
-				EditorGUI.LabelField(new Rect(0, top, position.width, height), "Missing", "Select PMD Prefab");
-			else if (vmdFile == null)
-				EditorGUI.LabelField(new Rect(0, top, position.width, height), "Missing", "Select VMD File");
-			else
-				EditorGUI.LabelField(new Rect(0, top, position.width, height), "Missing", "Select PMD and VMD");
+			GUI.enabled = gui_enabled_old;
 		}
 	}
 
 	void LoadMotion() {
 		string file_path = AssetDatabase.GetAssetPath(vmdFile);
 		MMD.MotionAgent motion_agent = new MMD.MotionAgent(file_path);
-		motion_agent.CreateAnimationClip(pmdPrefab, createAnimationFile,interpolationQuality);
+		motion_agent.CreateAnimationClip(pmdPrefab
+										, vmd_config.createAnimationFile
+										, vmd_config.interpolationQuality
+										);
 	}
 }


### PR DESCRIPTION
# 不具合修正
- MFUをインストール済み状態だとUnity起動直後にInspector版が機能しない不具合の修正
- ConfigWindowでの変更がConfig.assetに記録されない不具合の修正
- ConfigWindowの「Default PMD Import Config」に於いてスケールの設定が無かった不具合の修正
- Window版を表示したまま再生ボタンを押すとフリーズする不具合の修正
- Inspector版のオプションが変更出来無い不具合の修正
- VMDLoaderに於ける「Interpolation Quality」の初期値が範囲外だった不具合の修正
- VMDLoader(Window)のUIが他に比べて少し大きかった不具合の修正
# 変更
- 各所に散らばっているOnGUIの描画処理をConfig.csに集約
- 再生中は変換不可に統一(PMDLoader(Window)・VMDLoader(Window)・VMDLoader(Inspector)が変換不可に変更)
- Config.assetをInspector上で編集可能に変更
- Configに於ける「Use PMD Preload」と「Use VMD Preload」の初期値をオンに変更
- ConfigWindowに於ける上部文字列「MMD for Unity Configuration」の廃止
- Window版に於いてオブジェクト未設定の「Missing～」表記を廃止
- Inspector版に於けるモデル情報表記を薄いコントラストから通常のコントラストに変更
- PMDLoaderに於ける「Use PMX Base Import」の初期値をオンに変更
- PMDLoader(Inspector)に於ける「0.085」倍への設定表記を「0.085」から「Original」へ変更
